### PR TITLE
Adds MCP new chat mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "id": "copilot",
-  "name": "Copilot",
+  "id": "copirate",
+  "name": "Copirate",
   "version": "2.8.9",
   "minAppVersion": "0.15.0",
-  "description": "Your AI Copilot: Chat with Your Second Brain, Learn Faster, Work Smarter.",
+  "description": "Your AI copirate: Chat with Your Second Brain, Learn Faster, Work Smarter.",
   "author": "Logan Yang",
   "authorUrl": "https://twitter.com/logancyang",
   "fundingUrl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "obsidian-copilot",
       "version": "2.8.9",
+      "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -25,6 +26,7 @@
         "@langchain/mistralai": "^0.2.0",
         "@langchain/openai": "^0.5.6",
         "@langchain/xai": "^0.0.2",
+        "@modelcontextprotocol/sdk": "^1.12.1",
         "@orama/orama": "^3.0.0-rc-2",
         "@radix-ui/react-checkbox": "^1.1.3",
         "@radix-ui/react-collapsible": "^1.1.2",
@@ -4719,6 +4721,27 @@
         "zod": ">= 3"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.2.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
@@ -9188,7 +9211,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9629,6 +9651,123 @@
         "node": ">=8"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -9783,6 +9922,14 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cache-content-type": {
@@ -10396,6 +10543,22 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/cookies": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
@@ -10417,6 +10580,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-jest": {
@@ -11860,6 +12035,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -11881,12 +12064,31 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.0.0.tgz",
       "integrity": "sha512-9jgfSCa3dmEme2ES3mPByGXfgZ87VbP97tng1G2nWwWx6bV2nYxm2AWCrbQjXToSe+yYlqaZNtxffR9IeQr95g==",
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/eventsource/node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -11942,6 +12144,206 @@
       "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
       "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg=="
     },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
+    "node_modules/express/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/express/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -11985,8 +12387,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -12017,8 +12418,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -12141,6 +12541,59 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/finalhandler/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/find-up": {
@@ -12285,6 +12738,14 @@
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
@@ -13117,7 +13578,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -13240,6 +13700,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -13577,6 +14045,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "devOptional": true
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -15094,8 +15567,7 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -16476,6 +16948,17 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -17638,7 +18121,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -18059,6 +18541,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -18426,6 +18916,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -18518,6 +19020,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/react": {
@@ -19130,6 +19677,50 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -19229,8 +19820,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -19270,6 +19860,90 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -19297,6 +19971,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-function-length": {
@@ -20717,6 +21413,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -20751,7 +21455,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -21165,8 +21868,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "test": "jest --testPathIgnorePatterns=src/integration_tests/",
     "test:integration": "jest src/integration_tests/",
-    "prepare": "husky"
+    "prepare": "husky",
+    "install": "npm run build && cp ./main.js ./styles.css ./manifest.json ~/Vaults/Personal/.obsidian/plugins/copirate/"
   },
   "keywords": [],
   "author": "Logan Yang",
@@ -91,6 +92,7 @@
     "@langchain/mistralai": "^0.2.0",
     "@langchain/openai": "^0.5.6",
     "@langchain/xai": "^0.0.2",
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "@orama/orama": "^3.0.0-rc-2",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-collapsible": "^1.1.2",

--- a/src/LLMProviders/mcpClient.test.ts
+++ b/src/LLMProviders/mcpClient.test.ts
@@ -1,0 +1,241 @@
+// Mock the MCP SDK modules
+const mockConnect = jest.fn();
+const mockClose = jest.fn();
+const mockRequest = jest.fn();
+
+const MockClient = jest.fn().mockImplementation(() => ({
+  connect: mockConnect,
+  close: mockClose,
+  request: mockRequest,
+}));
+
+const MockSSEClientTransport = jest.fn().mockImplementation(() => ({
+  close: jest.fn(),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: MockClient,
+}));
+
+jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: MockSSEClientTransport,
+}));
+
+jest.mock("@modelcontextprotocol/sdk/types.js", () => ({
+  ListToolsRequestSchema: {},
+  CallToolRequestSchema: {},
+  ListResourcesRequestSchema: {},
+  ReadResourceRequestSchema: {},
+}));
+
+import { MCPClientManager, MCPServerConfig } from "./mcpClient";
+
+describe("MCPClientManager", () => {
+  let mcpClient: MCPClientManager;
+
+  beforeEach(() => {
+    // Get a fresh instance for each test
+    mcpClient = MCPClientManager.getInstance();
+    // Clear any existing servers
+    mcpClient.disconnectAll();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mcpClient.disconnectAll();
+  });
+
+  describe("Server Management", () => {
+    it("should add and track servers", () => {
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+        enabled: false, // Don't auto-connect for this test
+      };
+
+      mcpClient.addServer(serverConfig);
+
+      const servers = mcpClient.getAllServerConfigs();
+      expect(servers).toHaveLength(1);
+      expect(servers[0].name).toBe("test-server");
+    });
+
+    it("should remove servers", async () => {
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+        enabled: false,
+      };
+
+      mcpClient.addServer(serverConfig);
+      expect(mcpClient.getAllServerConfigs()).toHaveLength(1);
+
+      await mcpClient.removeServer("test-server");
+      expect(mcpClient.getAllServerConfigs()).toHaveLength(0);
+    });
+
+    it("should check server connection status", () => {
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+        enabled: false,
+      };
+
+      expect(mcpClient.isServerConnected("test-server")).toBe(false);
+
+      mcpClient.addServer(serverConfig);
+      expect(mcpClient.isServerConnected("test-server")).toBe(false); // Still false since auto-connect is disabled
+    });
+  });
+
+  describe("Connection Management", () => {
+    it("should connect to servers", async () => {
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+        enabled: false,
+      };
+
+      // Setup mocks
+      mockConnect.mockResolvedValue(undefined);
+      mockRequest.mockResolvedValue({ result: { tools: [], resources: [] } });
+
+      mcpClient.addServer(serverConfig);
+      await mcpClient.connectToServer("test-server");
+
+      expect(MockSSEClientTransport).toHaveBeenCalledWith(new URL("http://localhost:3000/sse"));
+      expect(MockClient).toHaveBeenCalled();
+      expect(mockConnect).toHaveBeenCalled();
+      expect(mcpClient.isServerConnected("test-server")).toBe(true);
+    });
+
+    it("should disconnect from servers", async () => {
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+        enabled: false,
+      };
+
+      // Setup mocks
+      mockConnect.mockResolvedValue(undefined);
+      mockClose.mockResolvedValue(undefined);
+      mockRequest.mockResolvedValue({ result: { tools: [], resources: [] } });
+
+      mcpClient.addServer(serverConfig);
+      await mcpClient.connectToServer("test-server");
+      expect(mcpClient.isServerConnected("test-server")).toBe(true);
+
+      await mcpClient.disconnectFromServer("test-server");
+      expect(mockClose).toHaveBeenCalled();
+      expect(mcpClient.isServerConnected("test-server")).toBe(false);
+    });
+  });
+
+  describe("Tool Management", () => {
+    beforeEach(async () => {
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+        enabled: false,
+      };
+
+      // Setup mocks for tools
+      mockConnect.mockResolvedValue(undefined);
+      mockRequest.mockImplementation((request) => {
+        if (request.method === "tools/list") {
+          return Promise.resolve({
+            result: {
+              tools: [
+                {
+                  name: "echo",
+                  description: "Echo back the input",
+                  inputSchema: { type: "object", properties: { text: { type: "string" } } },
+                },
+              ],
+            },
+          });
+        }
+        if (request.method === "resources/list") {
+          return Promise.resolve({ result: { resources: [] } });
+        }
+        return Promise.resolve({});
+      });
+
+      mcpClient.addServer(serverConfig);
+      await mcpClient.connectToServer("test-server");
+    });
+
+    it("should load tools from connected servers", () => {
+      const tools = mcpClient.getAllMCPTools();
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe("@mcp-test-server-echo");
+      expect(tools[0].description).toBe("[test-server] Echo back the input");
+    });
+
+    it("should get tools from specific server", () => {
+      const serverTools = mcpClient.getServerTools("test-server");
+      expect(serverTools).toHaveLength(1);
+      expect(serverTools[0].name).toBe("echo");
+    });
+  });
+
+  describe("Tool Execution", () => {
+    it("should execute tools on servers", async () => {
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+        enabled: false,
+      };
+
+      const mockResponse = { result: "Hello, World!" };
+      mockConnect.mockResolvedValue(undefined);
+      mockRequest.mockResolvedValue(mockResponse);
+
+      mcpClient.addServer(serverConfig);
+      await mcpClient.connectToServer("test-server");
+
+      const result = await mcpClient.executeTool("test-server", "echo", { text: "Hello, World!" });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockRequest).toHaveBeenCalledWith(
+        {
+          method: "tools/call",
+          params: {
+            name: "echo",
+            arguments: { text: "Hello, World!" },
+          },
+        },
+        {}
+      );
+    });
+  });
+
+  describe("Connection Testing", () => {
+    it("should test server connections successfully", async () => {
+      mockConnect.mockResolvedValue(undefined);
+      mockClose.mockResolvedValue(undefined);
+      mockRequest.mockResolvedValue({ result: { tools: [] } });
+
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+      };
+
+      const result = await mcpClient.testConnection(serverConfig);
+      expect(result).toBe(true);
+      expect(MockSSEClientTransport).toHaveBeenCalledWith(new URL("http://localhost:3000/sse"));
+    });
+
+    it("should handle failed connections", async () => {
+      mockConnect.mockRejectedValue(new Error("Connection failed"));
+
+      const serverConfig: MCPServerConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+      };
+
+      const result = await mcpClient.testConnection(serverConfig);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/LLMProviders/mcpClient.ts
+++ b/src/LLMProviders/mcpClient.ts
@@ -1,0 +1,391 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { logError, logInfo } from "@/logger";
+
+export interface MCPServerConfig {
+  name: string;
+  sseUrl: string; // SSE endpoint URL
+  apiKey?: string; // Optional authentication
+  enabled?: boolean;
+}
+
+export interface MCPTool {
+  name: string;
+  description: string;
+  inputSchema: any;
+}
+
+export interface MCPResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+/**
+ * A proper MCP client that communicates with MCP servers via SSE
+ * This implementation uses the official MCP SDK with SSE transport
+ */
+export class MCPClientManager {
+  private static instance: MCPClientManager;
+  private clients: Map<string, Client> = new Map();
+  private transports: Map<string, SSEClientTransport> = new Map();
+  private servers: Map<string, MCPServerConfig> = new Map();
+  private tools: Map<string, MCPTool[]> = new Map();
+  private resources: Map<string, MCPResource[]> = new Map();
+
+  private constructor() {}
+
+  static getInstance(): MCPClientManager {
+    if (!MCPClientManager.instance) {
+      MCPClientManager.instance = new MCPClientManager();
+    }
+    return MCPClientManager.instance;
+  }
+
+  /**
+   * Add an MCP server configuration
+   */
+  addServer(serverConfig: MCPServerConfig): void {
+    this.servers.set(serverConfig.name, serverConfig);
+    // Don't auto-connect here - let the caller decide when to connect
+    // This prevents duplicate connections during initialization
+  }
+
+  /**
+   * Remove an MCP server
+   */
+  async removeServer(serverName: string): Promise<void> {
+    await this.disconnectFromServer(serverName);
+    this.servers.delete(serverName);
+    this.tools.delete(serverName);
+    this.resources.delete(serverName);
+  }
+
+  /**
+   * Connect to an MCP server via SSE
+   */
+  async connectToServer(serverName: string): Promise<void> {
+    const serverConfig = this.servers.get(serverName);
+    if (!serverConfig) {
+      throw new Error(`Server ${serverName} not found`);
+    }
+
+    try {
+      // Create SSE transport (skip OAuth for now)
+      const transport = new SSEClientTransport(new URL(serverConfig.sseUrl));
+
+      // Create and connect client
+      const client = new Client(
+        {
+          name: "obsidian-copilot",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {
+            tools: {},
+            resources: {},
+          },
+        }
+      );
+
+      await client.connect(transport);
+
+      this.clients.set(serverName, client);
+      this.transports.set(serverName, transport);
+
+      // Load tools and resources from the server (handle missing methods gracefully)
+      await Promise.allSettled([
+        this.loadServerTools(serverName),
+        this.loadServerResources(serverName),
+      ]);
+
+      logInfo(`Connected to MCP server: ${serverName}`);
+    } catch (error) {
+      logError(`Failed to connect to MCP server ${serverName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect from an MCP server
+   */
+  async disconnectFromServer(serverName: string): Promise<void> {
+    const client = this.clients.get(serverName);
+    const transport = this.transports.get(serverName);
+
+    if (client) {
+      try {
+        await client.close();
+        this.clients.delete(serverName);
+      } catch (error) {
+        logError(`Error closing client for server ${serverName}:`, error);
+      }
+    }
+
+    if (transport) {
+      try {
+        await transport.close();
+        this.transports.delete(serverName);
+      } catch (error) {
+        logError(`Error closing transport for server ${serverName}:`, error);
+      }
+    }
+
+    this.tools.delete(serverName);
+    this.resources.delete(serverName);
+    logInfo(`Disconnected from MCP server: ${serverName}`);
+  }
+
+  /**
+   * Load tools from a specific server
+   */
+  private async loadServerTools(serverName: string): Promise<void> {
+    const client = this.clients.get(serverName);
+    if (!client) {
+      throw new Error(`Client for server ${serverName} not found`);
+    }
+
+    try {
+      const response = await client.listTools();
+      logInfo(`Tools response from ${serverName}:`, response);
+
+      if (response.tools && Array.isArray(response.tools)) {
+        const mcpTools: MCPTool[] = response.tools.map((tool: Tool) => ({
+          name: tool.name,
+          description: tool.description || "",
+          inputSchema: tool.inputSchema || {},
+        }));
+
+        this.tools.set(serverName, mcpTools);
+        logInfo(`Loaded ${mcpTools.length} tools from server: ${serverName}`, mcpTools);
+      } else {
+        logInfo(`No tools found in response from ${serverName}`);
+      }
+    } catch (error: any) {
+      // Check if it's a "method not found" error
+      if (error.code === -32601 || error.message?.includes("Method not found")) {
+        logInfo(`Server ${serverName} does not support tools/list_tools method`);
+        this.tools.set(serverName, []); // Set empty array to indicate no tools
+      } else {
+        logError(`Failed to load tools from server ${serverName}:`, error);
+      }
+    }
+  }
+
+  /**
+   * Load resources from a specific server
+   */
+  private async loadServerResources(serverName: string): Promise<void> {
+    const client = this.clients.get(serverName);
+    if (!client) {
+      throw new Error(`Client for server ${serverName} not found`);
+    }
+
+    try {
+      const response = await client.listResources();
+
+      if (response.resources && Array.isArray(response.resources)) {
+        const mcpResources: MCPResource[] = response.resources.map((resource: any) => ({
+          uri: resource.uri,
+          name: resource.name,
+          description: resource.description,
+          mimeType: resource.mimeType,
+        }));
+
+        this.resources.set(serverName, mcpResources);
+        logInfo(`Loaded ${mcpResources.length} resources from server: ${serverName}`);
+      }
+    } catch (error: any) {
+      // Check if it's a "method not found" error
+      if (error.code === -32601 || error.message?.includes("Method not found")) {
+        logInfo(`Server ${serverName} does not support resources/list method`);
+        this.resources.set(serverName, []); // Set empty array to indicate no resources
+      } else {
+        logError(`Failed to load resources from server ${serverName}:`, error);
+      }
+    }
+  }
+
+  /**
+   * Get all available tools across all connected servers
+   */
+  getAllMCPTools(): Array<{ name: string; description: string; serverName: string }> {
+    const allTools: Array<{ name: string; description: string; serverName: string }> = [];
+
+    this.tools.forEach((tools, serverName) => {
+      tools.forEach((tool) => {
+        allTools.push({
+          name: `@mcp-${serverName}-${tool.name}`,
+          description: `[${serverName}] ${tool.description}`,
+          serverName: serverName,
+        });
+      });
+    });
+
+    return allTools;
+  }
+
+  /**
+   * Get tools from a specific server
+   */
+  getServerTools(serverName: string): MCPTool[] {
+    return this.tools.get(serverName) || [];
+  }
+
+  /**
+   * Get resources from a specific server
+   */
+  getServerResources(serverName: string): MCPResource[] {
+    return this.resources.get(serverName) || [];
+  }
+
+  /**
+   * Execute a tool on a specific server
+   */
+  async executeTool(serverName: string, toolName: string, arguments_: any): Promise<any> {
+    const client = this.clients.get(serverName);
+    if (!client) {
+      throw new Error(`Client for server ${serverName} not found`);
+    }
+
+    try {
+      const response = await client.callTool({
+        name: toolName,
+        arguments: arguments_,
+      });
+
+      logInfo(`Executed tool ${toolName} on server ${serverName}`);
+      return response;
+    } catch (error) {
+      logError(`Failed to execute tool ${toolName} on server ${serverName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Read a resource from a specific server
+   */
+  async readResource(serverName: string, uri: string): Promise<any> {
+    const client = this.clients.get(serverName);
+    if (!client) {
+      throw new Error(`Client for server ${serverName} not found`);
+    }
+
+    try {
+      const response = await client.readResource({ uri });
+
+      logInfo(`Read resource ${uri} from server ${serverName}`);
+      return response;
+    } catch (error) {
+      logError(`Failed to read resource ${uri} from server ${serverName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get all connected servers
+   */
+  getConnectedServers(): string[] {
+    return Array.from(this.clients.keys());
+  }
+
+  /**
+   * Check if a server is connected
+   */
+  isServerConnected(serverName: string): boolean {
+    return this.clients.has(serverName);
+  }
+
+  /**
+   * Refresh tools and resources from all servers
+   */
+  async refreshAllTools(): Promise<void> {
+    const refreshPromises = Array.from(this.clients.keys()).map(async (serverName) => {
+      try {
+        await this.loadServerTools(serverName);
+        await this.loadServerResources(serverName);
+      } catch (error) {
+        logError(`Failed to refresh server ${serverName}:`, error);
+      }
+    });
+
+    await Promise.all(refreshPromises);
+  }
+
+  /**
+   * Get server configuration
+   */
+  getServerConfig(serverName: string): MCPServerConfig | undefined {
+    return this.servers.get(serverName);
+  }
+
+  /**
+   * Get all server configurations
+   */
+  getAllServerConfigs(): MCPServerConfig[] {
+    return Array.from(this.servers.values());
+  }
+
+  /**
+   * Test connection to a server configuration
+   */
+  async testConnection(serverConfig: MCPServerConfig): Promise<boolean> {
+    try {
+      // Create a temporary transport and client for testing (skip OAuth)
+      const transport = new SSEClientTransport(new URL(serverConfig.sseUrl));
+
+      const client = new Client(
+        {
+          name: "obsidian-copilot-test",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {
+            tools: {},
+            resources: {},
+          },
+        }
+      );
+
+      await client.connect(transport);
+
+      // Test if we can list tools (but don't fail if method not found)
+      try {
+        await client.listTools();
+      } catch (error: any) {
+        if (error.code === -32601 || error.message?.includes("Method not found")) {
+          logInfo(
+            `Test server does not support tools/list_tools method, but connection is working`
+          );
+        } else {
+          throw error; // Re-throw other errors
+        }
+      }
+
+      await client.close();
+      await transport.close();
+
+      return true;
+    } catch (error) {
+      logError(`MCP server test connection failed for ${serverConfig.name}:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Disconnect all servers
+   */
+  async disconnectAll(): Promise<void> {
+    const disconnectPromises = Array.from(this.servers.keys()).map((serverName) =>
+      this.disconnectFromServer(serverName)
+    );
+    await Promise.all(disconnectPromises);
+
+    this.servers.clear();
+    this.tools.clear();
+    this.resources.clear();
+    logInfo("Disconnected from all MCP servers");
+  }
+}

--- a/src/LLMProviders/projectManager.ts
+++ b/src/LLMProviders/projectManager.ts
@@ -64,7 +64,8 @@ export default class ProjectManager {
         refreshIndex:
           getSettings().indexVaultToVectorStore === VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH &&
           (getChainType() === ChainType.VAULT_QA_CHAIN ||
-            getChainType() === ChainType.COPILOT_PLUS_CHAIN),
+            getChainType() === ChainType.COPILOT_PLUS_CHAIN ||
+            getChainType() === ChainType.PIRATE_CHAIN),
       });
     });
 

--- a/src/chainFactory.ts
+++ b/src/chainFactory.ts
@@ -54,6 +54,7 @@ export enum ChainType {
   LLM_CHAIN = "llm_chain",
   VAULT_QA_CHAIN = "vault_qa",
   COPILOT_PLUS_CHAIN = "copilot_plus",
+  PIRATE_CHAIN = "pirate",
   PROJECT_CHAIN = "project",
 }
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -182,6 +182,7 @@ const Chat: React.FC<ChatProps> = ({
       );
 
     // Extract Mentions (such as URLs) from original input message only if using Copilot Plus chain
+    // Disable URL processing for pirate mode
     const urlContextAddition =
       currentChain === ChainType.COPILOT_PLUS_CHAIN
         ? await mention.processUrls(inputMessage || "")
@@ -221,7 +222,7 @@ const Chat: React.FC<ChatProps> = ({
       context: {
         notes,
         urls:
-          currentChain === ChainType.COPILOT_PLUS_CHAIN
+          currentChain === ChainType.COPILOT_PLUS_CHAIN || currentChain === ChainType.PIRATE_CHAIN
             ? [...(urls || []), ...urlContextAddition.imageUrls]
             : urls || [],
       },
@@ -630,7 +631,10 @@ ${chatContent}`;
     setContextNotes([]);
     // Only modify includeActiveNote if in a non-COPILOT_PLUS_CHAIN mode
     // In COPILOT_PLUS_CHAIN mode, respect the settings.includeActiveNoteAsContext value
-    if (selectedChain !== ChainType.COPILOT_PLUS_CHAIN) {
+    if (
+      selectedChain !== ChainType.COPILOT_PLUS_CHAIN &&
+      selectedChain !== ChainType.PIRATE_CHAIN
+    ) {
       setIncludeActiveNote(false);
     } else {
       setIncludeActiveNote(settings.includeActiveNoteAsContext);
@@ -645,7 +649,10 @@ ${chatContent}`;
   useEffect(() => {
     if (settings.includeActiveNoteAsContext !== undefined) {
       // Only apply the setting if not in Project mode
-      if (selectedChain === ChainType.COPILOT_PLUS_CHAIN) {
+      if (
+        selectedChain === ChainType.COPILOT_PLUS_CHAIN ||
+        selectedChain === ChainType.PIRATE_CHAIN
+      ) {
         setIncludeActiveNote(settings.includeActiveNoteAsContext);
       } else {
         // In other modes, always disable including active note

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -170,6 +170,7 @@ export function ChatControls({
                   copilot plus (beta)
                 </div>
               )}
+              {selectedChain === ChainType.PIRATE_CHAIN && "pirate"}
               {selectedChain === ChainType.PROJECT_CHAIN && "projects (alpha)"}
               <ChevronDown className="tw-mt-0.5 tw-size-5" />
             </Button>
@@ -188,6 +189,13 @@ export function ChatControls({
               }}
             >
               vault QA
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => {
+                handleModeChange(ChainType.PIRATE_CHAIN);
+              }}
+            >
+              pirate
             </DropdownMenuItem>
             {isPlusUser ? (
               <DropdownMenuItem

--- a/src/components/chat-components/ContextControl.tsx
+++ b/src/components/chat-components/ContextControl.tsx
@@ -67,7 +67,7 @@ const ContextControl: React.FC<ChatControlsProps> = ({
     }
   };
 
-  if (selectedChain !== ChainType.COPILOT_PLUS_CHAIN) {
+  if (selectedChain !== ChainType.COPILOT_PLUS_CHAIN && selectedChain !== ChainType.PIRATE_CHAIN) {
     return null;
   }
 

--- a/src/components/chat-components/SuggestedPrompts.tsx
+++ b/src/components/chat-components/SuggestedPrompts.tsx
@@ -61,10 +61,11 @@ const SUGGESTED_PROMPTS: Record<string, NotePrompt> = {
   },
 };
 
-const PROMPT_KEYS: Record<ChainType, Array<keyof typeof SUGGESTED_PROMPTS>> = {
+const PROMPT_KEYS: Record<ChainType, (keyof typeof SUGGESTED_PROMPTS)[]> = {
   [ChainType.LLM_CHAIN]: ["activeNote", "quoteNote", "fun"],
   [ChainType.VAULT_QA_CHAIN]: ["qaVault", "qaVault", "quoteNote"],
   [ChainType.COPILOT_PLUS_CHAIN]: ["copilotPlus", "copilotPlus", "copilotPlus"],
+  [ChainType.PIRATE_CHAIN]: ["copilotPlus", "copilotPlus", "copilotPlus"],
   [ChainType.PROJECT_CHAIN]: ["copilotPlus", "copilotPlus", "copilotPlus"],
 };
 

--- a/src/components/modals/MCPToolsPickerModal.tsx
+++ b/src/components/modals/MCPToolsPickerModal.tsx
@@ -1,0 +1,278 @@
+import { MCPServerConfig } from "@/LLMProviders/mcpClient";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { updateSetting, useSettingsValue } from "@/settings/model";
+import { MCPToolsManager } from "@/tools/MCPTools";
+import { App, Modal } from "obsidian";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import ReactDOM from "react-dom/client";
+
+interface MCPToolsPickerModalProps {
+  app: App;
+  onClose: () => void;
+}
+
+interface ToolState {
+  serverName: string;
+  toolName: string;
+  enabled: boolean;
+  description: string;
+}
+
+interface ServerState {
+  name: string;
+  enabled: boolean;
+  tools: ToolState[];
+}
+
+const MCPToolsPickerComponent: React.FC<MCPToolsPickerModalProps> = ({ app, onClose }) => {
+  const settings = useSettingsValue();
+  const [servers, setServers] = useState<ServerState[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [alwaysSendTools, setAlwaysSendTools] = useState(settings.mcpAlwaysSendTools || false);
+
+  // Load disabled tools from settings (we'll need to add this field to settings)
+  const disabledTools = useMemo(() => {
+    return new Set(settings.mcpDisabledTools || []);
+  }, [settings.mcpDisabledTools]);
+
+  // Load MCP tools and organize by server
+  useEffect(() => {
+    const loadTools = async () => {
+      try {
+        const mcpManager = MCPToolsManager.getInstance();
+        await mcpManager.initialize();
+
+        const allTools = mcpManager.getAllMCPTools();
+        const mcpServers = settings.mcpServers || [];
+
+        // Group tools by server
+        const serverMap = new Map<string, ServerState>();
+
+        mcpServers.forEach((server: MCPServerConfig) => {
+          serverMap.set(server.name, {
+            name: server.name,
+            enabled: server.enabled !== false,
+            tools: [],
+          });
+        });
+
+        allTools.forEach((tool) => {
+          const serverState = serverMap.get(tool.serverName);
+          if (serverState) {
+            // tool.name is already in format @mcp-{serverName}-{toolName}
+            const toolId = tool.name;
+            // Extract the actual tool name from the prefixed format
+            const actualToolName = tool.name.replace(`@mcp-${tool.serverName}-`, "");
+            serverState.tools.push({
+              serverName: tool.serverName,
+              toolName: actualToolName,
+              enabled: !disabledTools.has(toolId),
+              description: tool.description,
+            });
+          }
+        });
+
+        setServers(Array.from(serverMap.values()));
+        setLoading(false);
+      } catch (error) {
+        console.error("Failed to load MCP tools:", error);
+        setLoading(false);
+      }
+    };
+
+    loadTools();
+  }, [settings.mcpServers, disabledTools]);
+
+  // Toggle individual tool
+  const toggleTool = useCallback((serverName: string, toolName: string) => {
+    setServers((prevServers) => {
+      return prevServers.map((server) => {
+        if (server.name === serverName) {
+          return {
+            ...server,
+            tools: server.tools.map((tool) => {
+              if (tool.toolName === toolName) {
+                return { ...tool, enabled: !tool.enabled };
+              }
+              return tool;
+            }),
+          };
+        }
+        return server;
+      });
+    });
+  }, []);
+
+  // Toggle entire server
+  const toggleServer = useCallback((serverName: string) => {
+    setServers((prevServers) => {
+      return prevServers.map((server) => {
+        if (server.name === serverName) {
+          const newEnabled = !server.enabled;
+          return {
+            ...server,
+            enabled: newEnabled,
+            tools: server.tools.map((tool) => ({ ...tool, enabled: newEnabled })),
+          };
+        }
+        return server;
+      });
+    });
+  }, []);
+
+  // Save changes
+  const handleSave = useCallback(() => {
+    const disabledToolIds = new Set<string>();
+
+    servers.forEach((server) => {
+      server.tools.forEach((tool) => {
+        if (!tool.enabled) {
+          const toolId = `@mcp-${tool.serverName}-${tool.toolName}`;
+          disabledToolIds.add(toolId);
+        }
+      });
+    });
+
+    // Update settings with disabled tools
+    updateSetting("mcpDisabledTools", Array.from(disabledToolIds));
+
+    // Update always send tools setting
+    updateSetting("mcpAlwaysSendTools", alwaysSendTools);
+
+    // Update server enabled states
+    const updatedServers = (settings.mcpServers || []).map((server: MCPServerConfig) => {
+      const serverState = servers.find((s) => s.name === server.name);
+      return {
+        ...server,
+        enabled: serverState?.enabled ?? server.enabled,
+      };
+    });
+    updateSetting("mcpServers", updatedServers);
+
+    onClose();
+  }, [servers, settings.mcpServers, alwaysSendTools, onClose]);
+
+  if (loading) {
+    return (
+      <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-p-8">
+        <div className="tw-text-muted">Loading MCP tools...</div>
+      </div>
+    );
+  }
+
+  if (servers.length === 0) {
+    return (
+      <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-p-8">
+        <div className="tw-text-center">
+          <div className="tw-mb-2 tw-text-muted">No MCP servers configured</div>
+          <div className="tw-text-sm tw-text-faint">
+            Add MCP servers in the plugin settings to use tools
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-h-full tw-flex-col">
+      <div className="tw-flex-1 tw-overflow-y-auto tw-p-4">
+        <div className="tw-mb-6 tw-rounded-md tw-border tw-border-border tw-p-4">
+          <div className="tw-flex tw-items-center tw-gap-3">
+            <Checkbox
+              checked={alwaysSendTools}
+              onCheckedChange={(checked) => setAlwaysSendTools(checked as boolean)}
+            />
+            <div className="tw-flex-1">
+              <div className="tw-font-medium">Always send all enabled tools</div>
+              <div className="tw-text-sm tw-text-muted">
+                Automatically include all enabled MCP tools with every chat message (no @ required)
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="tw-space-y-4">
+          {servers.map((server) => (
+            <div key={server.name} className="tw-rounded-md tw-border tw-border-border tw-p-4">
+              <div className="tw-mb-3 tw-flex tw-items-center tw-justify-between">
+                <div className="tw-flex tw-items-center tw-gap-2">
+                  <Checkbox
+                    checked={server.enabled}
+                    onCheckedChange={() => toggleServer(server.name)}
+                  />
+                  <h3 className="tw-font-medium">{server.name}</h3>
+                  <span className="tw-text-sm tw-text-muted">
+                    ({server.tools.filter((t) => t.enabled).length}/{server.tools.length} tools)
+                  </span>
+                </div>
+              </div>
+
+              {server.tools.length > 0 && (
+                <div className="tw-space-y-2 tw-pl-6">
+                  {server.tools.map((tool) => (
+                    <div
+                      key={`${server.name}-${tool.toolName}`}
+                      className="tw-flex tw-items-start tw-gap-2"
+                    >
+                      <Checkbox
+                        checked={tool.enabled}
+                        disabled={!server.enabled}
+                        onCheckedChange={() => toggleTool(server.name, tool.toolName)}
+                        className="tw-mt-0.5"
+                      />
+                      <div className="tw-flex-1">
+                        <div className="tw-text-sm tw-font-medium">
+                          @mcp-{server.name}-{tool.toolName}
+                        </div>
+                        {tool.description && (
+                          <div className="tw-mt-0.5 tw-text-xs tw-text-muted">
+                            {tool.description}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="tw-flex tw-items-center tw-justify-end tw-gap-2 tw-border-t tw-border-border tw-p-4">
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave}>Save Changes</Button>
+      </div>
+    </div>
+  );
+};
+
+export class MCPToolsPickerModal extends Modal {
+  private root: ReactDOM.Root | null = null;
+
+  constructor(app: App) {
+    super(app);
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.addClass("copilot-mcp-tools-picker-modal");
+    contentEl.style.height = "500px";
+    contentEl.createEl("h2", { text: "MCP Tools" });
+
+    const container = contentEl.createDiv({ cls: "copilot-mcp-tools-picker-container" });
+    container.style.height = "calc(100% - 50px)";
+    this.root = ReactDOM.createRoot(container);
+    this.root.render(<MCPToolsPickerComponent app={this.app} onClose={() => this.close()} />);
+  }
+
+  onClose() {
+    if (this.root) {
+      this.root.unmount();
+    }
+    const { contentEl } = this;
+    contentEl.empty();
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -142,6 +142,7 @@ export enum ChatModelProviders {
   COPILOT_PLUS = "copilot-plus",
   MISTRAL = "mistralai",
   DEEPSEEK = "deepseek",
+  MCP = "mcp",
 }
 
 export enum ModelCapability {
@@ -386,7 +387,10 @@ export type Provider = ChatModelProviders | EmbeddingModelProviders;
 
 export type SettingKeyProviders = Exclude<
   ChatModelProviders,
-  ChatModelProviders.OPENAI_FORMAT | ChatModelProviders.LM_STUDIO | ChatModelProviders.OLLAMA
+  | ChatModelProviders.OPENAI_FORMAT
+  | ChatModelProviders.LM_STUDIO
+  | ChatModelProviders.OLLAMA
+  | ChatModelProviders.MCP
 >;
 
 // Provider metadata interface
@@ -497,6 +501,12 @@ export const ProviderInfo: Record<Provider, ProviderMetadata> = {
   [EmbeddingModelProviders.COPILOT_PLUS_JINA]: {
     label: "Copilot Plus",
     host: "https://api.brevilabs.com/v1",
+    keyManagementURL: "",
+    listModelURL: "",
+  },
+  [ChatModelProviders.MCP]: {
+    label: "Model Context Protocol",
+    host: "local",
     keyManagementURL: "",
     listModelURL: "",
   },
@@ -615,7 +625,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   xaiApiKey: "",
   mistralApiKey: "",
   deepseekApiKey: "",
-  defaultChainType: ChainType.LLM_CHAIN,
+  defaultChainType: ChainType.PIRATE_CHAIN,
   defaultModelKey: ChatModels.GPT_41 + "|" + ChatModelProviders.OPENAI,
   embeddingModelKey: EmbeddingModels.OPENAI_EMBEDDING_SMALL + "|" + EmbeddingModelProviders.OPENAI,
   temperature: 0.1,
@@ -661,6 +671,9 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   lastDismissedVersion: null,
   passMarkdownImages: true,
   enableCustomPromptTemplating: true,
+  mcpServers: [],
+  mcpDisabledTools: [],
+  mcpAlwaysSendTools: false,
 };
 
 export const EVENT_NAMES = {

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -86,6 +86,7 @@ export class ContextProcessor {
         // 2. Apply chain restrictions only to supported files that are NOT md or canvas
         if (
           currentChain !== ChainType.COPILOT_PLUS_CHAIN &&
+          currentChain !== ChainType.PIRATE_CHAIN &&
           note.extension !== "md" &&
           note.extension !== "canvas"
         ) {
@@ -100,7 +101,10 @@ export class ContextProcessor {
         let content = await fileParserManager.parseFile(note, vault);
 
         // Special handling for embedded PDFs within markdown (only in Plus mode)
-        if (note.extension === "md" && currentChain === ChainType.COPILOT_PLUS_CHAIN) {
+        if (
+          note.extension === "md" &&
+          (currentChain === ChainType.COPILOT_PLUS_CHAIN || currentChain === ChainType.PIRATE_CHAIN)
+        ) {
           content = await this.processEmbeddedPDFs(content, vault, fileParserManager);
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import {
 } from "@/settings/model";
 import SharedState from "@/sharedState";
 import { FileParserManager } from "@/tools/FileParserManager";
+import { MCPToolsManager } from "@/tools/MCPTools";
 import {
   Editor,
   MarkdownView,
@@ -46,6 +47,7 @@ export default class CopilotPlugin extends Plugin {
   userMessageHistory: string[] = [];
   vectorStoreManager: VectorStoreManager;
   fileParserManager: FileParserManager;
+  mcpToolsManager: MCPToolsManager;
   settingsUnsubscriber?: () => void;
   private autocompleteService: AutocompleteService;
 
@@ -90,6 +92,10 @@ export default class CopilotPlugin extends Plugin {
 
     IntentAnalyzer.initTools(this.app.vault);
 
+    // Initialize MCP Tools Manager
+    this.mcpToolsManager = MCPToolsManager.getInstance();
+    await this.mcpToolsManager.initialize();
+
     this.registerEvent(
       this.app.workspace.on("editor-menu", (menu: Menu, editor: Editor) => {
         const selectedText = editor.getSelection().trim();
@@ -133,6 +139,11 @@ export default class CopilotPlugin extends Plugin {
 
     this.settingsUnsubscriber?.();
     this.autocompleteService?.destroy();
+
+    // Shutdown MCP connections
+    if (this.mcpToolsManager) {
+      await this.mcpToolsManager.shutdown();
+    }
 
     logInfo("Copilot plugin unloaded");
   }

--- a/src/search/indexEventHandler.ts
+++ b/src/search/indexEventHandler.ts
@@ -35,7 +35,10 @@ export class IndexEventHandler {
     }
 
     const currentChainType = getChainType();
-    if (currentChainType !== ChainType.COPILOT_PLUS_CHAIN) {
+    if (
+      currentChainType !== ChainType.COPILOT_PLUS_CHAIN &&
+      currentChainType !== ChainType.PIRATE_CHAIN
+    ) {
       return;
     }
 

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -1,4 +1,5 @@
 import { CustomModel, ProjectConfig } from "@/aiParams";
+import { MCPServerConfig } from "@/LLMProviders/mcpClient";
 import { atom, createStore, useAtomValue } from "jotai";
 import { v4 as uuidv4 } from "uuid";
 
@@ -105,6 +106,9 @@ export interface CopilotSettings {
   projectList: Array<ProjectConfig>;
   passMarkdownImages: boolean;
   enableCustomPromptTemplating: boolean;
+  mcpServers: Array<MCPServerConfig>;
+  mcpDisabledTools: string[];
+  mcpAlwaysSendTools: boolean;
 }
 
 export const settingsStore = createStore();

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -2,6 +2,7 @@ import { SettingItem } from "@/components/ui/setting-item";
 import { updateSetting, useSettingsValue } from "@/settings/model";
 import { PromptSortStrategy } from "@/types";
 import React from "react";
+import { MCPSettings } from "./MCPSettings";
 
 export const AdvancedSettings: React.FC = () => {
   const settings = useSettingsValue();
@@ -62,6 +63,11 @@ export const AdvancedSettings: React.FC = () => {
             }}
           />
         </div>
+      </section>
+
+      {/* MCP Settings Section */}
+      <section>
+        <MCPSettings />
       </section>
     </div>
   );

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -21,6 +21,7 @@ const ChainType2Label: Record<ChainType, string> = {
   [ChainType.LLM_CHAIN]: "Chat",
   [ChainType.VAULT_QA_CHAIN]: "Vault QA (Basic)",
   [ChainType.COPILOT_PLUS_CHAIN]: "Copilot Plus (beta)",
+  [ChainType.PIRATE_CHAIN]: "Pirate",
   [ChainType.PROJECT_CHAIN]: "Projects (alpha)",
 };
 

--- a/src/settings/v2/components/MCPSettings.tsx
+++ b/src/settings/v2/components/MCPSettings.tsx
@@ -1,0 +1,333 @@
+import { Button } from "@/components/ui/button";
+import { SettingItem } from "@/components/ui/setting-item";
+import { MCPServerConfig } from "@/LLMProviders/mcpClient";
+import { updateSetting, useSettingsValue } from "@/settings/model";
+import { MCPToolsManager } from "@/tools/MCPTools";
+import { logError } from "@/logger";
+import { Notice } from "obsidian";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+
+export const MCPSettings: React.FC = () => {
+  const settings = useSettingsValue();
+  const [isAdding, setIsAdding] = useState(false);
+  const [newServer, setNewServer] = useState<MCPServerConfig>({
+    name: "",
+    sseUrl: "",
+    apiKey: "",
+    enabled: true,
+  });
+  const [mcpTools, setMcpTools] = useState<
+    Array<{ name: string; description: string; serverName: string }>
+  >([]);
+
+  const mcpServers = useMemo(() => settings.mcpServers || [], [settings.mcpServers]);
+  const mcpManager = MCPToolsManager.getInstance();
+
+  // Load tools on component mount and when servers change
+  const loadMcpTools = useCallback(async () => {
+    try {
+      // Ensure MCPToolsManager is initialized
+      await mcpManager.initialize();
+
+      // Small delay to allow tools to be loaded from servers
+      setTimeout(() => {
+        const tools = mcpManager.getAllMCPTools();
+        console.log("MCPSettings: Loaded tools:", tools);
+        setMcpTools(tools);
+      }, 1000); // Give time for server connection and tool loading
+    } catch (error) {
+      logError("Failed to load MCP tools:", error);
+    }
+  }, [mcpManager]);
+
+  useEffect(() => {
+    loadMcpTools();
+  }, [mcpServers, loadMcpTools]); // Reload when servers change
+
+  const addServer = async () => {
+    if (!newServer.name.trim() || !newServer.sseUrl.trim()) {
+      new Notice("Please provide both server name and SSE URL");
+      return;
+    }
+
+    try {
+      const updatedServers = [...mcpServers, { ...newServer }];
+      updateSetting("mcpServers", updatedServers);
+
+      // Try to connect to the new server
+      await mcpManager.addServer(newServer);
+
+      // Reset form
+      setNewServer({
+        name: "",
+        sseUrl: "",
+        apiKey: "",
+        enabled: true,
+      });
+      setIsAdding(false);
+
+      new Notice(`MCP server "${newServer.name}" added successfully`);
+
+      // Reload tools after adding server
+      setTimeout(() => {
+        loadMcpTools();
+      }, 1000); // Give server time to connect and load tools
+    } catch (error) {
+      logError("Failed to add MCP server:", error);
+      new Notice(
+        `Failed to add MCP server: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    }
+  };
+
+  const removeServer = async (serverName: string) => {
+    try {
+      const updatedServers = mcpServers.filter((server) => server.name !== serverName);
+      updateSetting("mcpServers", updatedServers);
+
+      // Disconnect from the server
+      await mcpManager.removeServer(serverName);
+
+      // Reload tools after removing server
+      await loadMcpTools();
+    } catch (error) {
+      logError("Failed to remove MCP server:", error);
+      new Notice(
+        `Failed to remove MCP server: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    }
+  };
+
+  const toggleServer = async (serverName: string, enabled: boolean) => {
+    try {
+      const updatedServers = mcpServers.map((server) =>
+        server.name === serverName ? { ...server, enabled } : server
+      );
+      updateSetting("mcpServers", updatedServers);
+
+      if (enabled) {
+        const serverConfig = updatedServers.find((s) => s.name === serverName);
+        if (serverConfig) {
+          await mcpManager.addServer(serverConfig);
+        }
+      } else {
+        await mcpManager.removeServer(serverName);
+      }
+
+      new Notice(`MCP server "${serverName}" ${enabled ? "enabled" : "disabled"}`);
+
+      // Reload tools after toggling server
+      setTimeout(() => {
+        loadMcpTools();
+      }, 1000); // Give server time to connect/disconnect
+    } catch (error) {
+      logError("Failed to toggle MCP server:", error);
+      new Notice(
+        `Failed to toggle MCP server: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    }
+  };
+
+  const testConnection = async (serverConfig: MCPServerConfig) => {
+    try {
+      const mcpClient = mcpManager["mcpClient"];
+      const result = await mcpClient.testConnection(serverConfig);
+
+      if (result) {
+        new Notice(`Connection to "${serverConfig.name}" successful!`);
+      } else {
+        new Notice(`Connection to "${serverConfig.name}" failed!`);
+      }
+    } catch (error) {
+      logError("Failed to test connection:", error);
+      new Notice(
+        `Connection test failed: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    }
+  };
+
+  const refreshConnections = async () => {
+    try {
+      await mcpManager.refreshConnections();
+      new Notice("MCP connections refreshed");
+
+      // Reload tools after refreshing connections
+      setTimeout(() => {
+        loadMcpTools();
+      }, 1000); // Give time for tools to be reloaded
+    } catch (error) {
+      logError("Failed to refresh connections:", error);
+      new Notice("Failed to refresh connections");
+    }
+  };
+
+  return (
+    <div className="tw-space-y-6">
+      {/* Header */}
+      <section>
+        <h3 className="tw-mb-4 tw-text-lg tw-font-semibold">Model Context Protocol (MCP)</h3>
+        <p className="tw-mb-4 tw-text-sm tw-text-faint">
+          Configure MCP (Model Context Protocol) servers via Server-Sent Events to extend Copilot
+          with external tools and data sources.
+        </p>
+
+        <div className="tw-mb-4 tw-flex tw-gap-2">
+          <Button
+            onClick={() => setIsAdding(true)}
+            disabled={isAdding}
+            variant="secondary"
+            size="sm"
+          >
+            Add MCP Server
+          </Button>
+          <Button onClick={refreshConnections} variant="secondary" size="sm">
+            Refresh Connections
+          </Button>
+        </div>
+      </section>
+
+      {/* Add New Server Form */}
+      {isAdding && (
+        <section className="tw-space-y-4 tw-rounded-lg tw-border tw-p-4">
+          <h4 className="tw-font-medium">Add New MCP Server</h4>
+
+          <SettingItem
+            type="text"
+            title="Server Name"
+            description="A unique name for this MCP server"
+            value={newServer.name}
+            onChange={(value) => setNewServer({ ...newServer, name: value })}
+            placeholder="my-server"
+          />
+
+          <SettingItem
+            type="text"
+            title="SSE URL"
+            description="Server-Sent Events endpoint for the MCP server"
+            value={newServer.sseUrl}
+            onChange={(value) => setNewServer({ ...newServer, sseUrl: value })}
+            placeholder="http://localhost:3000/sse or https://api.example.com/mcp/sse"
+          />
+
+          <SettingItem
+            type="text"
+            title="API Key"
+            description="Optional authentication key for the server"
+            value={newServer.apiKey || ""}
+            onChange={(value) => setNewServer({ ...newServer, apiKey: value })}
+            placeholder="your-api-key (optional)"
+          />
+
+          <div className="tw-flex tw-gap-2">
+            <Button onClick={addServer} size="sm">
+              Add Server
+            </Button>
+            <Button onClick={() => setIsAdding(false)} variant="secondary" size="sm">
+              Cancel
+            </Button>
+          </div>
+        </section>
+      )}
+
+      {/* Existing Servers */}
+      <section>
+        <h4 className="tw-mb-4 tw-font-medium">Configured Servers</h4>
+
+        {mcpServers.length === 0 ? (
+          <p className="tw-text-sm tw-text-faint">No MCP servers configured</p>
+        ) : (
+          <div className="tw-space-y-3">
+            {mcpServers.map((server, index) => {
+              const isConnected = mcpManager.isServerConnected(server.name);
+
+              return (
+                <div key={index} className="tw-rounded-lg tw-border tw-p-4">
+                  <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between">
+                    <div className="tw-flex tw-items-center tw-gap-2">
+                      <h5 className="tw-font-medium">{server.name}</h5>
+                      <span
+                        className={`tw-rounded tw-px-2 tw-py-1 tw-text-xs ${
+                          isConnected
+                            ? "tw-bg-modifier-success tw-text-on-accent"
+                            : "tw-bg-modifier-error tw-text-on-accent"
+                        }`}
+                      >
+                        {isConnected ? "Connected" : "Disconnected"}
+                      </span>
+                    </div>
+
+                    <div className="tw-flex tw-items-center tw-gap-2">
+                      <SettingItem
+                        type="switch"
+                        title=""
+                        description=""
+                        checked={server.enabled !== false}
+                        onCheckedChange={(enabled) => toggleServer(server.name, enabled)}
+                      />
+                      <Button onClick={() => testConnection(server)} variant="secondary" size="sm">
+                        Test
+                      </Button>
+                      <Button
+                        onClick={() => removeServer(server.name)}
+                        variant="destructive"
+                        size="sm"
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="tw-text-sm tw-text-faint">
+                    <p>
+                      <strong>SSE URL:</strong> {server.sseUrl}
+                    </p>
+                    {server.apiKey && (
+                      <p>
+                        <strong>API Key:</strong> {"*".repeat(8)}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* Available Tools */}
+      <section>
+        <div className="tw-mb-4 tw-flex tw-items-center tw-justify-between">
+          <div>
+            <h4 className="tw-font-medium">Available MCP Tools</h4>
+            <p className="tw-text-xs tw-text-faint">
+              {mcpTools.length} tools from{" "}
+              {mcpServers.filter((s) => mcpManager.isServerConnected(s.name)).length} connected
+              servers
+            </p>
+          </div>
+          <Button onClick={() => loadMcpTools()} variant="secondary" size="sm">
+            Refresh Tools
+          </Button>
+        </div>
+        {(() => {
+          if (mcpTools.length === 0) {
+            return (
+              <p className="tw-text-sm tw-text-faint">No tools available from connected servers</p>
+            );
+          }
+
+          return (
+            <div className="tw-space-y-2">
+              {mcpTools.map((tool, index) => (
+                <div key={index} className="tw-rounded tw-border tw-p-3">
+                  <div className="tw-text-sm tw-font-medium">{tool.name}</div>
+                  <div className="tw-text-xs tw-text-faint">{tool.description}</div>
+                </div>
+              ))}
+            </div>
+          );
+        })()}
+      </section>
+    </div>
+  );
+};

--- a/src/tools/MCPTools.test.ts
+++ b/src/tools/MCPTools.test.ts
@@ -1,0 +1,184 @@
+// Mock the MCP SDK modules first
+jest.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: jest.fn(),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: jest.fn(),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/types.js", () => ({
+  ListToolsRequestSchema: {},
+  CallToolRequestSchema: {},
+  ListResourcesRequestSchema: {},
+  ReadResourceRequestSchema: {},
+}));
+
+// Mock Obsidian Notice
+jest.mock("obsidian", () => ({
+  Notice: jest.fn(),
+}));
+
+import { MCPToolsManager } from "./MCPTools";
+import { MCPClientManager } from "@/LLMProviders/mcpClient";
+
+// Mock the MCPClientManager
+jest.mock("@/LLMProviders/mcpClient");
+jest.mock("@/settings/model", () => ({
+  getSettings: () => ({
+    mcpServers: [],
+  }),
+}));
+
+const mockMCPClient = {
+  getAllMCPTools: jest.fn(),
+  isServerConnected: jest.fn(),
+  addServer: jest.fn(),
+  connectToServer: jest.fn(),
+  removeServer: jest.fn(),
+  executeTool: jest.fn(),
+  refreshAllTools: jest.fn(),
+  testConnection: jest.fn(),
+  disconnectAll: jest.fn(),
+};
+
+(MCPClientManager.getInstance as jest.Mock).mockReturnValue(mockMCPClient);
+
+describe("MCPToolsManager", () => {
+  let mcpManager: MCPToolsManager;
+
+  beforeEach(() => {
+    mcpManager = MCPToolsManager.getInstance();
+    jest.clearAllMocks();
+  });
+
+  describe("Tool Management", () => {
+    it("should get all MCP tools", () => {
+      const mockTools = [
+        {
+          name: "@mcp-server1-tool1",
+          description: "[server1] Tool 1 description",
+          serverName: "server1",
+        },
+      ];
+
+      mockMCPClient.getAllMCPTools.mockReturnValue(mockTools);
+
+      const tools = mcpManager.getAllMCPTools();
+      expect(tools).toEqual(mockTools);
+      expect(mockMCPClient.getAllMCPTools).toHaveBeenCalled();
+    });
+
+    it("should check if tool is MCP tool", () => {
+      expect(mcpManager.isMCPTool("@mcp-server1-tool1")).toBe(true);
+      expect(mcpManager.isMCPTool("@vault")).toBe(false);
+      expect(mcpManager.isMCPTool("regular-tool")).toBe(false);
+    });
+
+    it("should get tool descriptions", () => {
+      const mockTools = [
+        {
+          name: "@mcp-server1-tool1",
+          description: "[server1] Tool 1",
+          serverName: "server1",
+        },
+        {
+          name: "@mcp-server2-tool2",
+          description: "[server2] Tool 2",
+          serverName: "server2",
+        },
+      ];
+
+      mockMCPClient.getAllMCPTools.mockReturnValue(mockTools);
+
+      const descriptions = mcpManager.getToolDescriptions();
+      expect(descriptions).toEqual({
+        "@mcp-server1-tool1": "[server1] Tool 1",
+        "@mcp-server2-tool2": "[server2] Tool 2",
+      });
+    });
+  });
+
+  describe("Tool Execution", () => {
+    it("should execute MCP tools correctly", async () => {
+      const toolName = "@mcp-server1-echo";
+      const args = { text: "Hello" };
+      const expectedResult = { output: "Hello" };
+
+      mockMCPClient.isServerConnected.mockReturnValue(true);
+      mockMCPClient.executeTool.mockResolvedValue(expectedResult);
+
+      const result = await mcpManager.executeMCPTool(toolName, args);
+
+      expect(mockMCPClient.executeTool).toHaveBeenCalledWith("server1", "echo", args);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("should throw error for invalid tool name format", async () => {
+      await expect(mcpManager.executeMCPTool("invalid-tool", {})).rejects.toThrow(
+        "Invalid MCP tool name format: invalid-tool"
+      );
+    });
+
+    it("should throw error for disconnected server", async () => {
+      mockMCPClient.isServerConnected.mockReturnValue(false);
+
+      await expect(mcpManager.executeMCPTool("@mcp-server1-tool", {})).rejects.toThrow(
+        "MCP server server1 is not connected"
+      );
+    });
+  });
+
+  describe("Server Management", () => {
+    it("should check server connection status", () => {
+      mockMCPClient.isServerConnected.mockReturnValue(true);
+
+      const isConnected = mcpManager.isServerConnected("test-server");
+      expect(isConnected).toBe(true);
+      expect(mockMCPClient.isServerConnected).toHaveBeenCalledWith("test-server");
+    });
+
+    it("should add servers", async () => {
+      const serverConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+      };
+
+      mockMCPClient.testConnection.mockResolvedValue(true);
+      mockMCPClient.addServer.mockImplementation(() => {});
+      mockMCPClient.connectToServer.mockResolvedValue(undefined);
+
+      await mcpManager.addServer(serverConfig);
+
+      expect(mockMCPClient.testConnection).toHaveBeenCalledWith(serverConfig);
+      expect(mockMCPClient.addServer).toHaveBeenCalledWith(serverConfig);
+      expect(mockMCPClient.connectToServer).toHaveBeenCalledWith("test-server");
+    });
+
+    it("should handle connection test failures", async () => {
+      const serverConfig = {
+        name: "test-server",
+        sseUrl: "http://localhost:3000/sse",
+      };
+
+      mockMCPClient.testConnection.mockResolvedValue(false);
+
+      await expect(mcpManager.addServer(serverConfig)).rejects.toThrow("Connection test failed");
+    });
+
+    it("should remove servers", async () => {
+      await mcpManager.removeServer("test-server");
+      expect(mockMCPClient.removeServer).toHaveBeenCalledWith("test-server");
+    });
+
+    it("should refresh connections", async () => {
+      await mcpManager.refreshConnections();
+      expect(mockMCPClient.refreshAllTools).toHaveBeenCalled();
+    });
+
+    it("should shutdown properly", async () => {
+      await mcpManager.shutdown();
+      expect(mockMCPClient.disconnectAll).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tools/MCPTools.ts
+++ b/src/tools/MCPTools.ts
@@ -1,0 +1,237 @@
+import { MCPClientManager } from "@/LLMProviders/mcpClient";
+import { getSettings } from "@/settings/model";
+import { logError, logInfo } from "@/logger";
+import { Notice } from "obsidian";
+
+export class MCPToolsManager {
+  private static instance: MCPToolsManager;
+  private mcpClient: MCPClientManager;
+  private initialized = false;
+
+  private constructor() {
+    this.mcpClient = MCPClientManager.getInstance();
+  }
+
+  static getInstance(): MCPToolsManager {
+    if (!MCPToolsManager.instance) {
+      MCPToolsManager.instance = new MCPToolsManager();
+    }
+    return MCPToolsManager.instance;
+  }
+
+  /**
+   * Initialize MCP servers from settings
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    try {
+      const settings = getSettings();
+      const mcpServers = settings.mcpServers || [];
+
+      for (const serverConfig of mcpServers) {
+        if (serverConfig.enabled !== false) {
+          this.mcpClient.addServer(serverConfig);
+          try {
+            await this.mcpClient.connectToServer(serverConfig.name);
+          } catch (error) {
+            logError(`Failed to connect to MCP server ${serverConfig.name}:`, error);
+          }
+        }
+      }
+
+      this.initialized = true;
+      logInfo(`MCP Tools Manager initialized with ${mcpServers.length} servers`);
+    } catch (error) {
+      logError("Failed to initialize MCP Tools Manager:", error);
+    }
+  }
+
+  /**
+   * Get all available MCP tools formatted for tool discovery
+   */
+  getAllMCPTools(): Array<{ name: string; description: string; serverName: string }> {
+    return this.mcpClient.getAllMCPTools();
+  }
+
+  /**
+   * Get enabled MCP tools only (excluding disabled ones from settings)
+   */
+  getEnabledMCPTools(): Array<{ name: string; description: string; serverName: string }> {
+    const settings = getSettings();
+    const disabledTools = new Set(settings.mcpDisabledTools || []);
+
+    return this.mcpClient.getAllMCPTools().filter((tool) => {
+      const toolId = `@mcp-${tool.serverName}-${tool.name}`;
+      return !disabledTools.has(toolId);
+    });
+  }
+
+  /**
+   * Execute an MCP tool
+   */
+  async executeMCPTool(toolName: string, args: any): Promise<any> {
+    try {
+      // Check if tool is disabled
+      const settings = getSettings();
+      const disabledTools = new Set(settings.mcpDisabledTools || []);
+      if (disabledTools.has(toolName)) {
+        throw new Error(`MCP tool ${toolName} is disabled`);
+      }
+
+      // Parse tool name to extract server and tool name
+      // Format: @mcp-{serverName}-{toolName}
+      const match = toolName.match(/^@mcp-(.+?)-(.+)$/);
+      if (!match) {
+        throw new Error(`Invalid MCP tool name format: ${toolName}`);
+      }
+
+      const [, serverName, actualToolName] = match;
+
+      if (!this.mcpClient.isServerConnected(serverName)) {
+        throw new Error(`MCP server ${serverName} is not connected`);
+      }
+
+      const result = await this.mcpClient.executeTool(serverName, actualToolName, args);
+      logInfo(`Executed MCP tool ${actualToolName} on server ${serverName}`);
+
+      return result;
+    } catch (error) {
+      logError(`Failed to execute MCP tool ${toolName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if a tool name is an MCP tool
+   */
+  isMCPTool(toolName: string): boolean {
+    return toolName.startsWith("@mcp-");
+  }
+
+  /**
+   * Get tool schema for a specific MCP tool
+   */
+  getMCPToolSchema(toolName: string): any {
+    try {
+      const match = toolName.match(/^@mcp-(.+?)-(.+)$/);
+      if (!match) {
+        return null;
+      }
+
+      const [, serverName, actualToolName] = match;
+      const serverTools = this.mcpClient.getServerTools(serverName);
+      const tool = serverTools.find((t) => t.name === actualToolName);
+
+      return tool?.inputSchema || null;
+    } catch (error) {
+      logError(`Failed to get MCP tool schema for ${toolName}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Refresh all MCP server connections and tools
+   */
+  async refreshConnections(): Promise<void> {
+    try {
+      await this.mcpClient.refreshAllTools();
+      logInfo("Refreshed all MCP server connections");
+    } catch (error) {
+      logError("Failed to refresh MCP connections:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if a server is connected
+   */
+  isServerConnected(serverName: string): boolean {
+    return this.mcpClient.isServerConnected(serverName);
+  }
+
+  /**
+   * Get connection status for all servers
+   */
+  getConnectionStatus(): Array<{ serverName: string; connected: boolean }> {
+    const settings = getSettings();
+    const mcpServers = settings.mcpServers || [];
+
+    return mcpServers.map((server) => ({
+      serverName: server.name,
+      connected: this.mcpClient.isServerConnected(server.name),
+    }));
+  }
+
+  /**
+   * Add a new MCP server configuration
+   */
+  async addServer(serverConfig: any): Promise<void> {
+    try {
+      // Test connection first
+      const testResult = await this.mcpClient.testConnection(serverConfig);
+      if (!testResult) {
+        throw new Error("Connection test failed");
+      }
+
+      this.mcpClient.addServer(serverConfig);
+      await this.mcpClient.connectToServer(serverConfig.name);
+
+      logInfo(`Added and connected to MCP server: ${serverConfig.name}`);
+      new Notice(`Successfully connected to MCP server: ${serverConfig.name}`);
+    } catch (error) {
+      logError(`Failed to add MCP server ${serverConfig.name}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Remove an MCP server
+   */
+  async removeServer(serverName: string): Promise<void> {
+    try {
+      this.mcpClient.removeServer(serverName);
+      logInfo(`Removed MCP server: ${serverName}`);
+      new Notice(`Removed MCP server: ${serverName}`);
+    } catch (error) {
+      logError(`Failed to remove MCP server ${serverName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get tools from a specific server
+   */
+  getServerTools(serverName: string): any[] {
+    return this.mcpClient.getServerTools(serverName);
+  }
+
+  /**
+   * Get formatted tool descriptions for UI display
+   */
+  getToolDescriptions(): Record<string, string> {
+    const descriptions: Record<string, string> = {};
+    const tools = this.getAllMCPTools();
+
+    tools.forEach((tool) => {
+      descriptions[tool.name] = tool.description;
+    });
+
+    return descriptions;
+  }
+
+  /**
+   * Shutdown all MCP connections
+   */
+  async shutdown(): Promise<void> {
+    try {
+      await this.mcpClient.disconnectAll();
+      this.initialized = false;
+      logInfo("MCP Tools Manager shutdown complete");
+    } catch (error) {
+      logError("Error during MCP Tools Manager shutdown:", error);
+    }
+  }
+}

--- a/src/tools/toolManager.ts
+++ b/src/tools/toolManager.ts
@@ -1,6 +1,14 @@
 import { Notice } from "obsidian";
+import { MCPToolsManager } from "./MCPTools";
 
 export const getToolDescription = (tool: string): string => {
+  // Check if it's an MCP tool first
+  const mcpManager = MCPToolsManager.getInstance();
+  if (mcpManager.isMCPTool(tool)) {
+    const descriptions = mcpManager.getToolDescriptions();
+    return descriptions[tool] || "MCP tool";
+  }
+
   switch (tool) {
     case "@vault":
       return "Search through your vault for relevant information";
@@ -22,6 +30,12 @@ export class ToolManager {
     try {
       if (!tool) {
         throw new Error("Tool is undefined");
+      }
+
+      // Check if this is an MCP tool call
+      const mcpManager = MCPToolsManager.getInstance();
+      if (typeof tool === "string" && mcpManager.isMCPTool(tool)) {
+        return await mcpManager.executeMCPTool(tool, args);
       }
 
       const result = await tool.call(args);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -192,6 +192,8 @@ export const stringToChainType = (chain: string): ChainType => {
       return ChainType.VAULT_QA_CHAIN;
     case "copilot_plus":
       return ChainType.COPILOT_PLUS_CHAIN;
+    case "pirate":
+      return ChainType.PIRATE_CHAIN;
     default:
       throw new Error(`Unknown chain type: ${chain}`);
   }


### PR DESCRIPTION
## Summary
- add `PIRATE_CHAIN` chain type and pirate mode
- implement `PirateChainRunner` without broca
- add pirate option in UI and settings
- support pirate context features in chat
- document PirateChainRunner logic
- Add an MCP client

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9634fd48325862de1a1714cf1a9